### PR TITLE
Small change to DRMSetupWizard.cpp

### DIFF
--- a/Source/DRMSetupWizard.cpp
+++ b/Source/DRMSetupWizard.cpp
@@ -116,31 +116,18 @@ void DRMPage::checkOriginExists()
     QDir originRoot;
     QDir originFolder;
 #if defined(_WIN32) || defined(_WIN64)
-    originRoot = QDir(qgetenv("APPDATA").append("/Origin"));
+    QSettings settings("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Origin", QSettings::NativeFormat);
+    if (settings.contains("ClientPath"))
+    {
+        originRoot = QFileInfo(settings.value("ClientPath").toString()).dir();
+    }
 #else
     originRoot = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).append("/Origin/");
 #endif
 
-
-    if (originRoot.exists())
+    if (originFolder == QDir("."))
     {
-        pt::ptree originTree;
-        read_xml(originRoot.filePath("local.xml").toLocal8Bit().constData(), originTree);
-
-
-        for (auto &xmlIter : originTree.get_child("Settings"))
-        {
-            if (xmlIter.second.get<std::string>("<xmlattr>.key") == "DownloadInPlaceDir")
-            {
-                originFolder = QString::fromStdString(xmlIter.second.get<std::string>("<xmlattr>.value"));
-                break;
-            }
-        }
-
-        if (originFolder == QDir("."))
-        {
-            originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
-        }
+        originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
     }
     else
     {

--- a/Source/DRMSetupWizard.cpp
+++ b/Source/DRMSetupWizard.cpp
@@ -120,8 +120,8 @@ void DRMPage::checkOriginExists()
     if (settings.contains("ClientPath"))
     {
         originRoot = QFileInfo(settings.value("ClientPath").toString()).dir();
-        originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
     }
+    originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
 #else
     originRoot = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).append("/Origin/");
 #endif

--- a/Source/DRMSetupWizard.cpp
+++ b/Source/DRMSetupWizard.cpp
@@ -120,19 +120,11 @@ void DRMPage::checkOriginExists()
     if (settings.contains("ClientPath"))
     {
         originRoot = QFileInfo(settings.value("ClientPath").toString()).dir();
+        originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
     }
 #else
     originRoot = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).append("/Origin/");
 #endif
-
-    if (originFolder == QDir("."))
-    {
-        originFolder = QDir("C:\\Program Files (x86)\\Origin Games\\");
-    }
-    else
-    {
-        return;
-    }
 
     if (originFolder.filePath("").trimmed() != "" && originFolder.exists())
     {


### PR DESCRIPTION
Check for Origin using the registry instead of AppData. I was going to include some changes that would've (possibly) fixed #21, but I wanted to get this in a PR now.
