### PR TITLE
Fix #66 Get wrong CONFIG_FOLDER before App-Init

### DIFF
--- a/Source/Defines.h
+++ b/Source/Defines.h
@@ -1,1 +1,1 @@
-#define CONFIG_FOLDER QStandardPaths::writableLocation(QStandardPaths::DataLocation)
+#define CONFIG_FOLDER QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QDir::separator() + "HorizonLauncher"


### PR DESCRIPTION
When reading CONFIG_FOLDER for the static DB,
the application-name was not set. Now its added
manually.
