### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Horizon Launcher Client Repository
+# Horizon Launcher Client Repository
 
 [![Slack Status](http://slack.launchhorizon.com/badge.svg)](http://slack.launchhorizon.com)
 [![Chat on Freenode](https://img.shields.io/badge/chat-on%20freenode-blue.svg?style=flat)](https://kiwiirc.com/client/chat.freenode.net/#horizonlauncher)

--- a/Translations/README.md
+++ b/Translations/README.md
@@ -1,4 +1,4 @@
-#Horizon Launcher Localization
+# Horizon Launcher Localization
 
 [![Slack Status](http://horizonlauncher-slack.herokuapp.com/badge.svg)](http://slack.launchhorizon.com)
 [![Chat on Freenode](https://img.shields.io/badge/chat-on%20freenode-blue.svg?style=flat)](https://kiwiirc.com/client/chat.freenode.net/#horizonlauncher)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
